### PR TITLE
Properly renomarlize lowpass filters and resampling filters

### DIFF
--- a/julius/lowpass.py
+++ b/julius/lowpass.py
@@ -82,7 +82,9 @@ class LowPassFilters(torch.nn.Module):
         filters = []
         for cutoff in cutoffs:
             filter_ = 2 * cutoff * window * sinc(2 * cutoff * math.pi * time)
-            filters.append(filter_)
+            # Normalize filter to have sum = 1, otherwise we will have a small leakage
+            # of the constant component in the input signal.
+            filters.append(filter_ / filter_.sum())
         self.register_buffer("filters", torch.stack(filters)[:, None])
 
     def forward(self, input):

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ URL = 'https://github.com/adefossez/julius'
 EMAIL = 'alexandre.defossez@gmail.com'
 AUTHOR = 'Alexandre Défossez'
 REQUIRES_PYTHON = '>=3.6.0'
-VERSION = "0.2.1"
+VERSION = "0.2.2"
 
 HERE = Path(__file__).parent
 

--- a/tests/test_lowpass.py
+++ b/tests/test_lowpass.py
@@ -82,6 +82,13 @@ class TestLowPassFilters(_BaseTest):
         jitted = th.jit.script(mod)
         self.assertEqual(list(jitted(x).shape), [128])
 
+    def test_constant(self):
+        x = th.ones(2048)
+        for zeros in [4, 10]:
+            for freq in [0.01, 0.1]:
+                y_low = lowpass_filter(x, freq, zeros=zeros)
+                self.assertLessEqual((y_low - 1).abs().mean(), 1e-6, (zeros, freq))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_resample.py
+++ b/tests/test_resample.py
@@ -114,6 +114,15 @@ class TestResampleFrac(_BaseTest):
         jitted = th.jit.script(mod)
         self.assertEqual(list(jitted(x).shape), [7 * 26])
 
+    def test_constant(self):
+        x = th.ones(4096)
+        for zeros in [4, 10]:
+            for old_sr in [1, 4, 10]:
+                for new_sr in [1, 4, 10]:
+                    y_low = resample.resample_frac(x, old_sr, new_sr, zeros=zeros)
+                    self.assertLessEqual(
+                        (y_low - 1).abs().mean(), 1e-6, (zeros, old_sr, new_sr))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Without this renomarlization, for small values of `zeros`, the filters will leak some very low frequencies (for instance a constant offset).