### PR TITLE
Fix ONNX compatibility for dynamic input lengths

### DIFF
--- a/julius/resample.py
+++ b/julius/resample.py
@@ -146,7 +146,7 @@ class ResampleFrac(torch.nn.Module):
             applied_output_length = torch.tensor(output_length)
             if full:
                 raise ValueError("You cannot pass both full=True and output_length")
-        return y[..., :applied_output_length]
+        return y[..., :applied_output_length]  # type: ignore
 
     def __repr__(self):
         return simple_repr(self)

--- a/julius/resample.py
+++ b/julius/resample.py
@@ -134,9 +134,10 @@ class ResampleFrac(torch.nn.Module):
         ys = F.conv1d(x, self.kernel, stride=self.old_sr)  # type: ignore
         y = ys.transpose(1, 2).reshape(list(shape[:-1]) + [-1])
 
-        float_output_length = self.new_sr * length / self.old_sr
-        max_output_length = int(math.ceil(float_output_length))
-        default_output_length = int(float_output_length)
+        float_output_length = torch.as_tensor(self.new_sr * length / self.old_sr)
+        max_output_length = torch.ceil(float_output_length).long()
+        default_output_length = torch.floor(float_output_length).long()
+
         if output_length is None:
             output_length = max_output_length if full else default_output_length
         elif output_length < 0 or output_length > max_output_length:

--- a/julius/resample.py
+++ b/julius/resample.py
@@ -139,13 +139,14 @@ class ResampleFrac(torch.nn.Module):
         default_output_length = torch.floor(float_output_length).long()
 
         if output_length is None:
-            output_length = max_output_length if full else default_output_length
+            applied_output_length = max_output_length if full else default_output_length
         elif output_length < 0 or output_length > max_output_length:
             raise ValueError(f"output_length must be between 0 and {max_output_length}")
         else:
+            applied_output_length = torch.tensor(output_length)
             if full:
                 raise ValueError("You cannot pass both full=True and output_length")
-        return y[..., :output_length]
+        return y[..., :applied_output_length]
 
     def __repr__(self):
         return simple_repr(self)

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     url=URL,
     packages=['julius'],
     install_requires=['torch>=1.7.0'],
-    extras_require={'dev': ['coverage', 'flake8', 'mypy', 'resampy', 'pdoc3']},
+    extras_require={'dev': ['coverage', 'flake8', 'mypy', 'onnxruntime', 'resampy', 'pdoc3']},
     include_package_data=True,
     license='MIT License',
     classifiers=[


### PR DESCRIPTION
Hey Alexandre 😄

julius.ResampleFrac was already ONNX-compatible, but only for a static input length (because the length provided as example during export was treated as a constant).

This PR adds support for dynamic input/output-lengths in exported ONNX files.

Motivation for improved ONNX-compatibility: onnxruntime is significantly faster than pytorch in the case of `ResampleFrac`, so it's nice to use that in production servers ⚡ 