### PR TITLE
Python o fix

### DIFF
--- a/julius/core.py
+++ b/julius/core.py
@@ -117,6 +117,7 @@ def unfold(input, kernel_size: int, stride: int):
     strides: tp.List[int] = []
     for dim in range(padded.dim()):
         strides.append(padded.stride(dim))
-    assert strides.pop(-1) == 1, 'data should be contiguous'
+    last_stride = strides.pop(-1)
+    assert last_stride == 1, 'data should be contiguous'
     strides = strides + [stride, 1]
     return padded.as_strided(shape + [n_frames, kernel_size], strides)


### PR DESCRIPTION
Fix for unintended side effect in unfold() assert statement that causes an exception when running with python -O.

Example error:
```
  File "/home/appuser/miniconda3/envs/jultest/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1750, in _call_impl
    return forward_call(*args, **kwargs)
  File "/home/appuser/miniconda3/envs/jultest/lib/python3.10/site-packages/julius/lowpass.py", line 107, in forward
    out = fft_conv1d(input, self.filters, stride=self.stride)
  File "/home/appuser/miniconda3/envs/jultest/lib/python3.10/site-packages/julius/fftconv.py", line 122, in fft_conv1d
    frames = unfold(input, block_size, fold_stride)
  File "/home/appuser/miniconda3/envs/jultest/lib/python3.10/site-packages/julius/core.py", line 122, in unfold
    return padded.as_strided(shape + [n_frames, kernel_size], strides)
RuntimeError: mismatch in length of strides and shape
```